### PR TITLE
fix(windows): do not take errors into account when CRC failed

### DIFF
--- a/internal/receive.go
+++ b/internal/receive.go
@@ -1,4 +1,4 @@
-// go:build !windows
+//go:build !windows
 
 package internal
 

--- a/internal/receive_windows.go
+++ b/internal/receive_windows.go
@@ -1,4 +1,4 @@
-// go:build windows
+//go:build windows
 
 package internal
 

--- a/internal/receive_windows.go
+++ b/internal/receive_windows.go
@@ -1,4 +1,4 @@
-// go:build !windows
+// go:build windows
 
 package internal
 
@@ -58,12 +58,8 @@ func ReceiveFrame(relay io.Reader, fr *frame.Frame) error {
 		}
 
 		if d, ok := relay.(deadliner); ok {
-			err = d.SetReadDeadline(time.Now().Add(time.Second * 2))
-			if err != nil {
-				return errors.E(op, errors.Errorf("CRC verification failed, bad header: %s", fr.Header()))
-			}
-
-			// we don't care about error here
+			// we don't care about errors here, because the pipe can be either closed, and then we read all data w/o deadline or deadline will be successfully set.
+			_ = d.SetReadDeadline(time.Now().Add(time.Second * 2))
 			resp, _ := io.ReadAll(relay)
 
 			return errors.E(op, errors.Errorf("CRC verification failed: %s", string(fr.Header())+string(resp)))


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1193

## Description of Changes

- `SetReadDeadline` operation fails on a closed pipe on windows, so, we can safely skip an error here and just read the rest of the data.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`) or (`git commit -S`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
